### PR TITLE
[Feature, #18] handle auth navigation

### DIFF
--- a/__mocks__/react-navigation.js
+++ b/__mocks__/react-navigation.js
@@ -2,11 +2,13 @@ const reactNavigation = jest.genMockFromModule('react-navigation')
 
 const mockStackNavigator = jest.fn()
 const mockTabNavigator = jest.fn()
+const mockSwitchNavigator = jest.fn()
 const mockAppContainer = () => null
 
 reactNavigation.createStackNavigator = jest.fn(() => mockStackNavigator)
 reactNavigation.createAppContainer = jest.fn(() => mockAppContainer)
 reactNavigation.createBottomTabNavigator = jest.fn(() => mockTabNavigator)
+reactNavigation.createSwitchNavigator = jest.fn(() => mockSwitchNavigator)
 reactNavigation.getActiveChildNavigationOptions = jest.fn()
 
 module.exports = reactNavigation

--- a/app/AppMain.js
+++ b/app/AppMain.js
@@ -6,7 +6,8 @@ import PropTypes from 'prop-types'
 import {
   createAppContainer,
   createBottomTabNavigator,
-  createStackNavigator
+  createStackNavigator,
+  createSwitchNavigator
 } from 'react-navigation'
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
@@ -17,16 +18,31 @@ import { restoreKeys } from './services/ir/actions'
 
 import About from './screens/About'
 import Balances from './screens/Balances'
+import Loading from './screens/Loading'
 import Settings from './screens/Settings'
 
 import styles from './styles'
 import useStorybook from './utils/useStorybook'
 import navigationOptions from './utils/tabNavigationOptions'
 
-const navBar = useStorybook({ Balances, Settings, About })
-const TabNavigator = createBottomTabNavigator(navBar, { navigationOptions })
-const StackNavigator = createStackNavigator({ TabNavigator })
-const AppContainer = createAppContainer(StackNavigator)
+const loggedInNavBar = useStorybook({ Balances, Settings, About })
+const LoggedInTabNavigator = createBottomTabNavigator(loggedInNavBar, {
+  navigationOptions
+})
+const LoggedInStackNavigator = createStackNavigator({ LoggedInTabNavigator })
+
+const loggedOutNavBar = useStorybook({ Settings, About })
+const LoggedOutTabNavigator = createBottomTabNavigator(loggedOutNavBar, {
+  navigationOptions
+})
+const LoggedOutStackNavigator = createStackNavigator({ LoggedOutTabNavigator })
+
+const MainNavigator = createSwitchNavigator(
+  { Loading, LoggedInStackNavigator, LoggedOutStackNavigator },
+  { initialRouteName: 'Loading' }
+)
+
+const AppContainer = createAppContainer(MainNavigator)
 
 class AppMain extends PureComponent {
   static propTypes = {

--- a/app/screens/About/__snapshots__/index.test.js.snap
+++ b/app/screens/About/__snapshots__/index.test.js.snap
@@ -16,52 +16,6 @@ exports[`rendering rendered correctly 1`] = `
     <Text
       style={
         Object {
-          "fontSize": 35,
-        }
-      }
-      theme={
-        Object {
-          "colors": Object {
-            "disabled": "hsl(208, 8%, 90%)",
-            "divider": "#bcbbc1",
-            "error": "#ff190c",
-            "grey0": "#393e42",
-            "grey1": "#43484d",
-            "grey2": "#5e6977",
-            "grey3": "#86939e",
-            "grey4": "#bdc6cf",
-            "grey5": "#e1e8ee",
-            "greyOutline": "#bbb",
-            "platform": Object {
-              "android": Object {
-                "error": "#f44336",
-                "primary": "#2196f3",
-                "secondary": "#9C27B0",
-                "success": "#4caf50",
-                "warning": "#ffeb3b",
-              },
-              "ios": Object {
-                "error": "#ff3b30",
-                "primary": "#007aff",
-                "secondary": "#5856d6",
-                "success": "#4cd964",
-                "warning": "#ffcc00",
-              },
-            },
-            "primary": "#2089dc",
-            "searchBg": "#303337",
-            "secondary": "#8F0CE8",
-            "success": "#52c41a",
-            "warning": "#faad14",
-          },
-        }
-      }
-    >
-      About
-    </Text>
-    <Text
-      style={
-        Object {
           "marginLeft": 10,
           "marginRight": 10,
           "paddingBottom": 10,
@@ -107,52 +61,6 @@ exports[`rendering rendered correctly 1`] = `
       }
     >
       Wonderfully written about-text goes here.
-    </Text>
-    <Text
-      style={
-        Object {
-          "fontSize": 27.5,
-        }
-      }
-      theme={
-        Object {
-          "colors": Object {
-            "disabled": "hsl(208, 8%, 90%)",
-            "divider": "#bcbbc1",
-            "error": "#ff190c",
-            "grey0": "#393e42",
-            "grey1": "#43484d",
-            "grey2": "#5e6977",
-            "grey3": "#86939e",
-            "grey4": "#bdc6cf",
-            "grey5": "#e1e8ee",
-            "greyOutline": "#bbb",
-            "platform": Object {
-              "android": Object {
-                "error": "#f44336",
-                "primary": "#2196f3",
-                "secondary": "#9C27B0",
-                "success": "#4caf50",
-                "warning": "#ffeb3b",
-              },
-              "ios": Object {
-                "error": "#ff3b30",
-                "primary": "#007aff",
-                "secondary": "#5856d6",
-                "success": "#4cd964",
-                "warning": "#ffcc00",
-              },
-            },
-            "primary": "#2089dc",
-            "searchBg": "#303337",
-            "secondary": "#8F0CE8",
-            "success": "#52c41a",
-            "warning": "#faad14",
-          },
-        }
-      }
-    >
-      Credits
     </Text>
     <Text
       style={

--- a/app/screens/About/index.js
+++ b/app/screens/About/index.js
@@ -19,11 +19,9 @@ export class AboutScreen extends PureComponent {
     return (
       <SafeAreaView style={styles.container}>
         <View>
-          <Text h3>About</Text>
           <Text style={styles.instructions}>
             Wonderfully written about-text goes here.
           </Text>
-          <Text h4>Credits</Text>
           <Text style={styles.instructions}>
             Nice things about the people who helped make it.
           </Text>

--- a/app/screens/Balances/__snapshots__/index.test.js.snap
+++ b/app/screens/Balances/__snapshots__/index.test.js.snap
@@ -13,52 +13,6 @@ exports[`rendering has no balances but is loading rendered correctly 1`] = `
   }
 >
   <View>
-    <Text
-      style={
-        Object {
-          "fontSize": 35,
-        }
-      }
-      theme={
-        Object {
-          "colors": Object {
-            "disabled": "hsl(208, 8%, 90%)",
-            "divider": "#bcbbc1",
-            "error": "#ff190c",
-            "grey0": "#393e42",
-            "grey1": "#43484d",
-            "grey2": "#5e6977",
-            "grey3": "#86939e",
-            "grey4": "#bdc6cf",
-            "grey5": "#e1e8ee",
-            "greyOutline": "#bbb",
-            "platform": Object {
-              "android": Object {
-                "error": "#f44336",
-                "primary": "#2196f3",
-                "secondary": "#9C27B0",
-                "success": "#4caf50",
-                "warning": "#ffeb3b",
-              },
-              "ios": Object {
-                "error": "#ff3b30",
-                "primary": "#007aff",
-                "secondary": "#5856d6",
-                "success": "#4cd964",
-                "warning": "#ffcc00",
-              },
-            },
-            "primary": "#2089dc",
-            "searchBg": "#303337",
-            "secondary": "#8F0CE8",
-            "success": "#52c41a",
-            "warning": "#faad14",
-          },
-        }
-      }
-    >
-      Balances
-    </Text>
     <View
       style={
         Array [
@@ -692,52 +646,6 @@ exports[`rendering when empty balances rendered correctly 1`] = `
   }
 >
   <View>
-    <Text
-      style={
-        Object {
-          "fontSize": 35,
-        }
-      }
-      theme={
-        Object {
-          "colors": Object {
-            "disabled": "hsl(208, 8%, 90%)",
-            "divider": "#bcbbc1",
-            "error": "#ff190c",
-            "grey0": "#393e42",
-            "grey1": "#43484d",
-            "grey2": "#5e6977",
-            "grey3": "#86939e",
-            "grey4": "#bdc6cf",
-            "grey5": "#e1e8ee",
-            "greyOutline": "#bbb",
-            "platform": Object {
-              "android": Object {
-                "error": "#f44336",
-                "primary": "#2196f3",
-                "secondary": "#9C27B0",
-                "success": "#4caf50",
-                "warning": "#ffeb3b",
-              },
-              "ios": Object {
-                "error": "#ff3b30",
-                "primary": "#007aff",
-                "secondary": "#5856d6",
-                "success": "#4cd964",
-                "warning": "#ffcc00",
-              },
-            },
-            "primary": "#2089dc",
-            "searchBg": "#303337",
-            "secondary": "#8F0CE8",
-            "success": "#52c41a",
-            "warning": "#faad14",
-          },
-        }
-      }
-    >
-      Balances
-    </Text>
     <View
       style={
         Array [
@@ -1373,52 +1281,6 @@ exports[`rendering when has balances and not loading rendered correctly 1`] = `
   }
 >
   <View>
-    <Text
-      style={
-        Object {
-          "fontSize": 35,
-        }
-      }
-      theme={
-        Object {
-          "colors": Object {
-            "disabled": "hsl(208, 8%, 90%)",
-            "divider": "#bcbbc1",
-            "error": "#ff190c",
-            "grey0": "#393e42",
-            "grey1": "#43484d",
-            "grey2": "#5e6977",
-            "grey3": "#86939e",
-            "grey4": "#bdc6cf",
-            "grey5": "#e1e8ee",
-            "greyOutline": "#bbb",
-            "platform": Object {
-              "android": Object {
-                "error": "#f44336",
-                "primary": "#2196f3",
-                "secondary": "#9C27B0",
-                "success": "#4caf50",
-                "warning": "#ffeb3b",
-              },
-              "ios": Object {
-                "error": "#ff3b30",
-                "primary": "#007aff",
-                "secondary": "#5856d6",
-                "success": "#4cd964",
-                "warning": "#ffcc00",
-              },
-            },
-            "primary": "#2089dc",
-            "searchBg": "#303337",
-            "secondary": "#8F0CE8",
-            "success": "#52c41a",
-            "warning": "#faad14",
-          },
-        }
-      }
-    >
-      Balances
-    </Text>
     <View
       style={
         Array [

--- a/app/screens/Balances/index.js
+++ b/app/screens/Balances/index.js
@@ -54,7 +54,6 @@ export class BalancesScreen extends Component {
 
     return (
       <View>
-        <Text h3>Balances</Text>
         <AccountBalances balances={balances} />
         <Button
           style={styles.button}

--- a/app/screens/Loading/__snapshots__/index.test.js.snap
+++ b/app/screens/Loading/__snapshots__/index.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rendering rendered correctly 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "flex": 1,
+      "justifyContent": "center",
+      "margin": 10,
+    }
+  }
+>
+  <ActivityIndicator
+    animating={true}
+    color="#999999"
+    hidesWhenStopped={true}
+    size="small"
+  />
+</View>
+`;

--- a/app/screens/Loading/index.js
+++ b/app/screens/Loading/index.js
@@ -1,0 +1,50 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import { View, ActivityIndicator } from 'react-native'
+import { connect } from 'react-redux'
+
+import { navigationShape, keysShape } from '../../shapes'
+
+import styles from './styles'
+
+export class LoadingScreen extends Component {
+  static propTypes = {
+    navigation: PropTypes.shape(navigationShape).isRequired,
+    keys: PropTypes.shape(keysShape),
+    loading: PropTypes.bool
+  }
+
+  static defaultProps = {
+    keys: null,
+    loading: true
+  }
+
+  componentDidUpdate(prevProps) {
+    const {
+      navigation: { navigate },
+      keys,
+      loading
+    } = this.props
+    if (!loading)
+      if (keys) navigate('LoggedInStackNavigator')
+      else navigate('LoggedOutStackNavigator')
+  }
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator />
+      </View>
+    )
+  }
+}
+
+export const mapStateToProps = ({ ir: { apiKey, apiSecret, busy } }) => ({
+  keys: apiKey && apiSecret ? { apiKey, apiSecret } : null,
+  loading: busy
+})
+
+export default connect(
+  mapStateToProps,
+  null
+)(LoadingScreen)

--- a/app/screens/Loading/index.test.js
+++ b/app/screens/Loading/index.test.js
@@ -1,0 +1,118 @@
+/**
+ * @format
+ */
+
+import 'react-native'
+import React from 'react'
+import renderer from 'react-test-renderer'
+
+import LoadingScreen, { mapStateToProps } from '.'
+
+const apiKey = 'some-key'
+const apiSecret = 'some-secret'
+const keys = { apiKey, apiSecret }
+
+const requireAuth = true
+const navigate = jest.fn()
+const navigation = { navigate }
+
+const resetStubs = () => {
+  navigate.clearMock()
+}
+
+describe('mapStateToProps', () => {
+  describe('when there are keys', () => {
+    const stateProps = mapStateToProps({
+      ir: { apiKey, apiSecret, busy: false }
+    })
+
+    it('returned keys', () => {
+      expect(stateProps).toHaveProperty('keys', keys)
+    })
+
+    it('returned loading', () => {
+      expect(stateProps).toHaveProperty('loading', false)
+    })
+  })
+
+  describe('when there are missing keys', () => {
+    const stateProps = mapStateToProps({
+      ir: { apiKey, apiSecret: null, requireAuth, busy: false }
+    })
+
+    it('returned keys is null', () => {
+      expect(stateProps).toHaveProperty('keys', null)
+    })
+
+    it('returned loading', () => {
+      expect(stateProps).toHaveProperty('loading', false)
+    })
+  })
+})
+
+describe('rendering', () => {
+  let tree
+
+  beforeAll(() => {
+    tree = renderer.create(
+      <LoadingScreen loading navigation={{ navigate: () => {} }} />
+    )
+  })
+
+  it('rendered correctly', () => {
+    expect(tree).toMatchSnapshot()
+  })
+})
+
+describe('is loading', () => {
+  beforeAll(() => {
+    renderer
+      .create(
+        <LoadingScreen loading={true} navigation={navigation} keys={null} />
+      )
+      .getInstance()
+      .componentDidUpdate({ navigation, loading: false, keys: null })
+  })
+
+  afterAll(resetStubs)
+
+  it("didn't call navigate", () => {
+    expect(navigate).not.toHaveBeenCalled()
+  })
+})
+
+describe('once loading is done', () => {
+  describe('when keys arrive', () => {
+    beforeAll(() => {
+      renderer
+        .create(
+          <LoadingScreen loading={false} navigation={navigation} keys={keys} />
+        )
+        .getInstance()
+        .componentDidUpdate({ navigation, loading: true, keys: null })
+    })
+
+    afterAll(resetStubs)
+
+    it('called navigate("LoggedInStackNavigator")', () => {
+      expect(navigate).toHaveBeenCalledWith('LoggedInStackNavigator')
+    })
+  })
+
+  describe('when keys do not arrive', () => {
+    beforeAll(() => {
+      renderer
+        .create(
+          <LoadingScreen loading={false} navigation={navigation} keys={null} />
+        )
+        .getInstance()
+        .componentDidUpdate({ navigation, loading: true, keys: null })
+    })
+
+    afterAll(resetStubs)
+
+    it('called navigate("LoggedOutStackNavigator")', () => {
+      expect(navigate).toHaveBeenCalledWith('LoggedOutStackNavigator')
+    })
+  })
+})

--- a/app/screens/Loading/styles.js
+++ b/app/screens/Loading/styles.js
@@ -1,0 +1,10 @@
+import { StyleSheet } from 'react-native'
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    margin: 10
+  }
+})

--- a/app/screens/Settings/__snapshots__/index.test.js.snap
+++ b/app/screens/Settings/__snapshots__/index.test.js.snap
@@ -52,52 +52,6 @@ exports[`rendering rendered correctly 1`] = `
         <Text
           style={
             Object {
-              "fontSize": 35,
-            }
-          }
-          theme={
-            Object {
-              "colors": Object {
-                "disabled": "hsl(208, 8%, 90%)",
-                "divider": "#bcbbc1",
-                "error": "#ff190c",
-                "grey0": "#393e42",
-                "grey1": "#43484d",
-                "grey2": "#5e6977",
-                "grey3": "#86939e",
-                "grey4": "#bdc6cf",
-                "grey5": "#e1e8ee",
-                "greyOutline": "#bbb",
-                "platform": Object {
-                  "android": Object {
-                    "error": "#f44336",
-                    "primary": "#2196f3",
-                    "secondary": "#9C27B0",
-                    "success": "#4caf50",
-                    "warning": "#ffeb3b",
-                  },
-                  "ios": Object {
-                    "error": "#ff3b30",
-                    "primary": "#007aff",
-                    "secondary": "#5856d6",
-                    "success": "#4cd964",
-                    "warning": "#ffcc00",
-                  },
-                },
-                "primary": "#2089dc",
-                "searchBg": "#303337",
-                "secondary": "#8F0CE8",
-                "success": "#52c41a",
-                "warning": "#faad14",
-              },
-            }
-          }
-        >
-          Settings
-        </Text>
-        <Text
-          style={
-            Object {
               "marginLeft": 10,
               "marginRight": 10,
               "paddingBottom": 10,

--- a/app/screens/Settings/index.js
+++ b/app/screens/Settings/index.js
@@ -39,7 +39,6 @@ export class SettingsScreen extends Component {
       <SafeAreaView style={styles.container}>
         <KeyboardAwareScrollView resetScrollToCoords={{ x: 0, y: 0 }}>
           <View>
-            <Text h3>Settings</Text>
             <Text style={styles.instructions}>
               An API key and secret are needed to interact with the Independent
               Reserve API.

--- a/app/screens/Settings/index.js
+++ b/app/screens/Settings/index.js
@@ -32,6 +32,24 @@ export class SettingsScreen extends Component {
     saving: false
   }
 
+  handleClearKeys = () => {
+    const {
+      navigation: { navigate },
+      doClearKeys
+    } = this.props
+    doClearKeys()
+    navigate('LoggedOutStackNavigator')
+  }
+
+  handleSaveKeys = keys => {
+    const {
+      navigation: { navigate },
+      doSaveKeys
+    } = this.props
+    doSaveKeys(keys)
+    navigate('LoggedInStackNavigator')
+  }
+
   render() {
     const { keys, requireAuth, doSaveKeys, saving, doClearKeys } = this.props
 
@@ -57,8 +75,8 @@ export class SettingsScreen extends Component {
             saving={saving}
             keys={keys}
             requireAuth={requireAuth}
-            onSave={doSaveKeys}
-            onClear={doClearKeys}
+            onSave={this.handleSaveKeys}
+            onClear={this.handleClearKeys}
           />
         </KeyboardAwareScrollView>
       </SafeAreaView>

--- a/app/screens/Settings/index.js
+++ b/app/screens/Settings/index.js
@@ -51,7 +51,7 @@ export class SettingsScreen extends Component {
   }
 
   render() {
-    const { keys, requireAuth, doSaveKeys, saving, doClearKeys } = this.props
+    const { keys, requireAuth, saving } = this.props
 
     return (
       <SafeAreaView style={styles.container}>

--- a/app/screens/Settings/index.test.js
+++ b/app/screens/Settings/index.test.js
@@ -11,8 +11,14 @@ import SettingsScreen, { mapStateToProps, mapDispatchToProps } from '.'
 const apiKey = 'some-key'
 const apiSecret = 'some-secret'
 const keys = { apiKey, apiSecret }
-
 const requireAuth = true
+
+const navigate = jest.fn()
+const navigation = { navigate }
+
+const resetStubs = () => {
+  navigate.clearMock()
+}
 
 let tree
 
@@ -66,8 +72,6 @@ describe('mapDispatchToProps', () => {
 })
 
 describe('rendering', () => {
-  const navigation = {}
-
   beforeAll(() => {
     tree = renderer.create(
       <SettingsScreen
@@ -82,5 +86,60 @@ describe('rendering', () => {
 
   it('rendered correctly', () => {
     expect(tree).toMatchSnapshot()
+  })
+})
+
+describe('when keys are saved', () => {
+  const doSaveKeys = jest.fn()
+
+  beforeAll(() => {
+    renderer
+      .create(
+        <SettingsScreen
+          doSaveKeys={doSaveKeys}
+          doClearKeys={() => {}}
+          navigation={navigation}
+        />
+      )
+      .getInstance()
+      .handleSaveKeys(keys)
+  })
+
+  afterAll(resetStubs)
+
+  it('called doSaveKeys with the keys', () => {
+    expect(doSaveKeys).toHaveBeenCalledWith(keys)
+  })
+
+  it('called navigate("LoggedInStackNavigator")', () => {
+    expect(navigate).toHaveBeenCalledWith('LoggedInStackNavigator')
+  })
+})
+
+describe('when keys are cleared', () => {
+  const doClearKeys = jest.fn()
+
+  beforeAll(() => {
+    renderer
+      .create(
+        <SettingsScreen
+          keys={keys}
+          doSaveKeys={() => {}}
+          doClearKeys={doClearKeys}
+          navigation={navigation}
+        />
+      )
+      .getInstance()
+      .handleClearKeys()
+  })
+
+  afterAll(resetStubs)
+
+  it('called doClearKeys', () => {
+    expect(doClearKeys).toHaveBeenCalled()
+  })
+
+  it('called navigate("LoggedOutStackNavigator")', () => {
+    expect(navigate).toHaveBeenCalledWith('LoggedOutStackNavigator')
   })
 })


### PR DESCRIPTION
* goes directly to the `Balances` screen if the keys are there on startup
* goes directly to the `Settings` screen if the keys are not there on startup
* if the user clears keys then it removes the `Balances` tab from the nav bar
* when the user adds keys then it adds the `Balances` tab to the nav bar

## not done

* nice error handling if the user enters bad keys
